### PR TITLE
Add Claude Code install targets

### DIFF
--- a/Sources/CodexSkillManager/Skills/Local/Skill.swift
+++ b/Sources/CodexSkillManager/Skills/Local/Skill.swift
@@ -18,6 +18,7 @@ struct Skill: Identifiable, Hashable {
     let name: String
     let displayName: String
     let description: String
+    let platform: SkillPlatform
     let folderURL: URL
     let skillMarkdownURL: URL
     let references: [SkillReference]
@@ -27,6 +28,7 @@ struct Skill: Identifiable, Hashable {
 
     var tagLabels: [String] {
         var labels: [String] = []
+        labels.append(platform.rawValue)
         labels.append(label(for: stats.references, singular: "reference"))
         labels.append(label(for: stats.assets, singular: "asset"))
         labels.append(label(for: stats.scripts, singular: "script"))

--- a/Sources/CodexSkillManager/Skills/Shared/InstallTargetSelectionView.swift
+++ b/Sources/CodexSkillManager/Skills/Shared/InstallTargetSelectionView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct InstallTargetSelectionView: View {
+    let installedTargets: Set<SkillPlatform>
+    @Binding var selection: Set<SkillPlatform>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Install for")
+                .font(.headline)
+
+            ForEach(SkillPlatform.allCases) { platform in
+                Toggle(isOn: binding(for: platform)) {
+                    HStack(spacing: 8) {
+                        Text(platform.rawValue)
+                        if installedTargets.contains(platform) {
+                            TagView(text: "Installed", tint: .green)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    Text(platform.rootURL.path)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .toggleStyle(.checkbox)
+    }
+
+    private func binding(for platform: SkillPlatform) -> Binding<Bool> {
+        Binding(
+            get: { selection.contains(platform) },
+            set: { isOn in
+                if isOn {
+                    selection.insert(platform)
+                } else {
+                    selection.remove(platform)
+                }
+            }
+        )
+    }
+}

--- a/Sources/CodexSkillManager/Skills/Shared/SkillPlatform.swift
+++ b/Sources/CodexSkillManager/Skills/Shared/SkillPlatform.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum SkillPlatform: String, CaseIterable, Identifiable, Hashable {
+    case codex = "Codex"
+    case claude = "Claude Code"
+
+    var id: String { rawValue }
+
+    var storageKey: String {
+        switch self {
+        case .codex:
+            return "codex"
+        case .claude:
+            return "claude"
+        }
+    }
+
+    var rootURL: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        switch self {
+        case .codex:
+            return home.appendingPathComponent(".codex/skills/public")
+        case .claude:
+            return home.appendingPathComponent(".claude/skills")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .codex:
+            return "Install in \(rootURL.path)"
+        case .claude:
+            return "Install in \(rootURL.path)"
+        }
+    }
+}

--- a/Sources/CodexSkillManager/Skills/Sidebar/RemoteSkillRowView.swift
+++ b/Sources/CodexSkillManager/Skills/Sidebar/RemoteSkillRowView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct RemoteSkillRowView: View {
     let skill: RemoteSkill
-    let isInstalled: Bool
+    let installedTargets: Set<SkillPlatform>
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -22,8 +22,10 @@ struct RemoteSkillRowView: View {
                     TagView(text: "v\(version)")
                 }
 
-                if isInstalled {
-                    TagView(text: "Installed", tint: .green)
+                ForEach(SkillPlatform.allCases) { platform in
+                    if installedTargets.contains(platform) {
+                        TagView(text: platform.rawValue, tint: .green)
+                    }
                 }
             }
         }

--- a/Sources/CodexSkillManager/Skills/Sidebar/SidebarHeaderView.swift
+++ b/Sources/CodexSkillManager/Skills/Sidebar/SidebarHeaderView.swift
@@ -17,7 +17,7 @@ struct SidebarHeaderView: View {
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(source == .local ? "Codex Skills" : "Clawdhub")
+                Text(source == .local ? "Installed Skills" : "Clawdhub")
                     .font(.title2.bold())
                     .foregroundStyle(.primary)
                 Text("\(skillCount) skills")


### PR DESCRIPTION
### Motivation

- Add first-class support for Claude Code skills so the app can manage both Codex and Claude skill collections.  
- Let users choose where a downloaded skill is installed (`Codex`, `Claude Code`, or both) instead of only installing to the Codex path.  
- Surface platform information in the UI so installed skills and remote rows show which platform(s) they belong to.

### Description

- Introduce a `SkillPlatform` enum and `InstallTargetSelectionView` to represent platforms and provide a reusable install-target picker UI (`Sources/.../Skills/Shared/SkillPlatform.swift`, `Sources/.../InstallTargetSelectionView.swift`).  
- Extend `Skill` with a `platform` field and show platform labels in skill tags (`Sources/.../Local/Skill.swift`).  
- Update `SkillStore` to scan multiple platform root folders, produce platform-prefixed IDs, track per-platform installs, and support installing a remote skill to multiple `destinations` (`Sources/.../Local/SkillStore.swift`).  
- Add UI changes to let users pick install targets during import and remote download flows, show a remote install sheet, split the local list into `Codex` / `Claude Code` sections, and annotate remote rows with installed platform tags (`Sources/.../Import/ImportSkillView.swift`, `Sources/.../SkillSplitView.swift`, `Sources/.../Sidebar/*`).

### Testing

- Ran `swift build` to validate the changes; build failed with the environment Swift tools mismatch: `error: package 'codexskillmanager' is using Swift tools version 6.2.0 but the installed version is 6.1.0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb7a111f8832588f4d01e3f8353fd)