### PR TITLE
Unify local skills list with Codex/Claude badges (Vibe Kanban)

### DIFF
--- a/Sources/CodexSkillManager/Skills/Local/Skill.swift
+++ b/Sources/CodexSkillManager/Skills/Local/Skill.swift
@@ -28,7 +28,6 @@ struct Skill: Identifiable, Hashable {
 
     var tagLabels: [String] {
         var labels: [String] = []
-        labels.append(platform.rawValue)
         labels.append(label(for: stats.references, singular: "reference"))
         labels.append(label(for: stats.assets, singular: "asset"))
         labels.append(label(for: stats.scripts, singular: "script"))

--- a/Sources/CodexSkillManager/Skills/Local/SkillStore.swift
+++ b/Sources/CodexSkillManager/Skills/Local/SkillStore.swift
@@ -57,6 +57,7 @@ import Observation
                 selectedSkillID = self.skills.first?.id
             }
 
+            normalizeSelectionToPreferredPlatform()
             await loadSelectedSkill()
         } catch {
             listState = .failed(error.localizedDescription)
@@ -133,6 +134,22 @@ import Observation
 
     func installedPlatforms(for slug: String) -> Set<SkillPlatform> {
         Set(skills.filter { $0.name == slug }.map(\.platform))
+    }
+
+    private func normalizeSelectionToPreferredPlatform() {
+        guard let selectedSkillID,
+              let selected = skills.first(where: { $0.id == selectedSkillID }) else {
+            return
+        }
+
+        let slug = selected.name
+        let candidates = skills.filter { $0.name == slug }
+        guard candidates.count > 1 else { return }
+
+        let preferred = candidates.first(where: { $0.platform == .codex }) ?? candidates.first
+        if let preferred, preferred.id != selectedSkillID {
+            self.selectedSkillID = preferred.id
+        }
     }
 
     func installRemoteSkill(

--- a/Sources/CodexSkillManager/Skills/Sidebar/SkillRowView.swift
+++ b/Sources/CodexSkillManager/Skills/Sidebar/SkillRowView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SkillRowView: View {
     let skill: Skill
+    let installedPlatforms: Set<SkillPlatform>
 
     private var visibleTags: [String] {
         Array(skill.tagLabels.prefix(3))
@@ -22,14 +23,19 @@ struct SkillRowView: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
 
-            if !skill.tagLabels.isEmpty {
-                HStack(spacing: 6) {
-                    ForEach(visibleTags, id: \.self) { tag in
-                        TagView(text: tag)
+            HStack(spacing: 6) {
+                ForEach(SkillPlatform.allCases) { platform in
+                    if installedPlatforms.contains(platform) {
+                        TagView(text: platform.rawValue, tint: .green)
                     }
-                    if overflowCount > 0 {
-                        TagView(text: "+\(overflowCount) more")
-                    }
+                }
+
+                ForEach(visibleTags, id: \.self) { tag in
+                    TagView(text: tag)
+                }
+
+                if overflowCount > 0 {
+                    TagView(text: "+\(overflowCount) more")
                 }
             }
         }

--- a/Sources/CodexSkillManager/Skills/SkillSplitView.swift
+++ b/Sources/CodexSkillManager/Skills/SkillSplitView.swift
@@ -23,14 +23,6 @@ struct SkillSplitView: View {
         }
     }
 
-    private var filteredCodexSkills: [Skill] {
-        filteredSkills.filter { $0.platform == .codex }
-    }
-
-    private var filteredClaudeSkills: [Skill] {
-        filteredSkills.filter { $0.platform == .claude }
-    }
-
     var body: some View {
         splitView
             .modifier(
@@ -81,8 +73,7 @@ struct SkillSplitView: View {
 
     private var listView: some View {
         SkillListView(
-            localCodexSkills: filteredCodexSkills,
-            localClaudeSkills: filteredClaudeSkills,
+            localSkills: filteredSkills,
             remoteLatestSkills: remoteStore.latestSkills,
             remoteSearchResults: remoteStore.searchResults,
             remoteSearchState: remoteStore.searchState,


### PR DESCRIPTION
## Summary
This updates the local (installed) skills sidebar to present a single unified list and show platform badges per skill.

## What changed
- Removed the separate local sidebar sections for "Codex" and "Claude Code".
- Grouped installed skills by slug so a skill installed in both locations appears once.
- Added platform badges on each row:
  - If installed in both, show both "Codex" and "Claude Code".
  - If installed in only one, show just that badge.
- Deleting a grouped row now deletes all installed copies for that skill (both platforms, when present).

## Why
The app now supports both Codex and Claude Code skill folders. Splitting the sidebar into sections makes duplicates likely and hides the fact that a skill can exist in both places. A unified list with explicit platform badges makes the installation state obvious at a glance.

## Implementation details
- `SkillListView` groups `localSkills` by slug for display, while using `store.skills` to compute the full installed platform set and the full deletion set (so filtering doesn’t break multi-platform actions).
- `SkillRowView` renders the platform badges first, then the existing metadata tags (references/assets/scripts/templates).
- `SkillStore` normalizes selection to prefer the Codex copy when both exist, keeping list selection stable with the grouped sidebar.

This PR was written using [Vibe Kanban](https://vibekanban.com)
