### PR TITLE
fix: activate app on launch when run via `swift run` fix #8

### DIFF
--- a/Sources/CodexSkillManager/App/CodexSkillManagerApp.swift
+++ b/Sources/CodexSkillManager/App/CodexSkillManagerApp.swift
@@ -35,6 +35,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 #endif
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Ensure the app becomes key when launched from `swift run`.
+        NSApplication.shared.setActivationPolicy(.regular)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
 #if canImport(Sparkle) && ENABLE_SPARKLE
         guard shouldEnableSparkle() else { return }
         updaterController = SPUStandardUpdaterController(


### PR DESCRIPTION
### Motivation
- Search bar typing events do not reach the app when launched from the terminal with `swift run` because the app never becomes key.  
- The change ensures the app receives keyboard focus so UI inputs like the search bar work when started via SwiftPM.  
- Make a minimal lifecycle change in the app delegate to restore expected behavior when running the executable directly.  
- Avoid altering the Sparkle updater logic which is already guarded by compile flags.

### Description
- Add activation logic to `applicationDidFinishLaunching` to make the app key when launched from `swift run`.  
- Call `NSApplication.shared.setActivationPolicy(.regular)` and `NSApplication.shared.activate(ignoringOtherApps: true)` in `Sources/CodexSkillManager/App/CodexSkillManagerApp.swift`.  
- Preserve the existing Sparkle initialization inside the `#if canImport(Sparkle) && ENABLE_SPARKLE` guard.  
- Changes were committed with the message `fix: activate app on launch`.

### Testing
- Ran `swift build`, which failed due to a Swift tools version mismatch (package requires `6.2.0`, installed `6.1.0`).  
- No further automated tests were executed in this environment due to the toolchain version constraint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fdcd3157883259ee7f3a892a6b8a7)