### PR TITLE
Add OpenCode skill platform support fix #7

### DIFF
--- a/Sources/CodexSkillManager/Skills/Local/SkillStore.swift
+++ b/Sources/CodexSkillManager/Skills/Local/SkillStore.swift
@@ -190,7 +190,7 @@ import Observation
 
     func groupedLocalSkills(from filteredSkills: [Skill]) -> [LocalSkillGroup] {
         let grouped = Dictionary(grouping: filteredSkills, by: { $0.name })
-        let preferredPlatformOrder: [SkillPlatform] = [.codex, .claude]
+        let preferredPlatformOrder: [SkillPlatform] = [.codex, .claude, .opencode]
 
         return grouped.compactMap { slug, filteredSkills in
             let allSkillsForSlug = skills.filter { $0.name == slug }
@@ -267,7 +267,10 @@ import Observation
         let candidates = skills.filter { $0.name == slug }
         guard candidates.count > 1 else { return }
 
-        let preferred = candidates.first(where: { $0.platform == .codex }) ?? candidates.first
+        let preferredOrder: [SkillPlatform] = [.codex, .claude, .opencode]
+        let preferred = preferredOrder
+            .compactMap { platform in candidates.first(where: { $0.platform == platform }) }
+            .first ?? candidates.first
         if let preferred, preferred.id != selectedSkillID {
             self.selectedSkillID = preferred.id
         }

--- a/Sources/CodexSkillManager/Skills/Shared/SkillPlatform.swift
+++ b/Sources/CodexSkillManager/Skills/Shared/SkillPlatform.swift
@@ -3,6 +3,7 @@ import SwiftUI
 enum SkillPlatform: String, CaseIterable, Identifiable, Hashable, Sendable {
     case codex = "Codex"
     case claude = "Claude Code"
+    case opencode = "OpenCode"
 
     var id: String { rawValue }
 
@@ -12,6 +13,8 @@ enum SkillPlatform: String, CaseIterable, Identifiable, Hashable, Sendable {
             return "codex"
         case .claude:
             return "claude"
+        case .opencode:
+            return "opencode"
         }
     }
 
@@ -22,6 +25,8 @@ enum SkillPlatform: String, CaseIterable, Identifiable, Hashable, Sendable {
             return home.appendingPathComponent(".codex/skills/public")
         case .claude:
             return home.appendingPathComponent(".claude/skills")
+        case .opencode:
+            return home.appendingPathComponent(".config/opencode/skill")
         }
     }
 
@@ -30,6 +35,8 @@ enum SkillPlatform: String, CaseIterable, Identifiable, Hashable, Sendable {
         case .codex:
             return "Install in \(rootURL.path)"
         case .claude:
+            return "Install in \(rootURL.path)"
+        case .opencode:
             return "Install in \(rootURL.path)"
         }
     }
@@ -40,6 +47,8 @@ enum SkillPlatform: String, CaseIterable, Identifiable, Hashable, Sendable {
             return Color(red: 164.0 / 255.0, green: 97.0 / 255.0, blue: 212.0 / 255.0)
         case .claude:
             return Color(red: 217.0 / 255.0, green: 119.0 / 255.0, blue: 87.0 / 255.0)
+        case .opencode:
+            return Color(red: 76.0 / 255.0, green: 144.0 / 255.0, blue: 226.0 / 255.0)
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Add explicit OpenCode support so skills can be installed and managed for OpenCode in the same way as Codex and Claude Code.
- Ensure OpenCode appears in UI lists, installation targets, and preferred selection ordering.

### Description
- Added a new `SkillPlatform` case `opencode` with `storageKey`, `rootURL` set to `~/.config/opencode/skill`, `description`, and a badge tint in `Sources/CodexSkillManager/Skills/Shared/SkillPlatform.swift`.
- Included `.opencode` in the preferred platform ordering used when grouping skills in `Sources/CodexSkillManager/Skills/Local/SkillStore.swift` so OpenCode-installed skills are considered alongside Codex and Claude.
- Updated selection normalization logic to prefer Codex, then Claude, then OpenCode when multiple platform variants of a skill exist.

### Testing
- Ran `swift build`, which failed due to Swift tools mismatch: package requires Swift tools `6.2.0` but the installed version is `6.1.0` (build did not complete).
- No additional automated tests were executed due to the toolchain/version constraint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fdcf2a22c8325aeef6e0749c14320)