### PR TITLE
Enable macOS 15 Sequoia Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "CodexSkillManager",
     platforms: [
-        .macOS(.v26),
+        .macOS(.v15),
     ],
     dependencies: [
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui.git", from: "2.4.1"),

--- a/Sources/CodexSkillManager/Skills/SkillSplitView.swift
+++ b/Sources/CodexSkillManager/Skills/SkillSplitView.swift
@@ -114,14 +114,19 @@ struct SkillSplitView: View {
                 .disabled(isDownloadingRemote || !canDownloadRemoteSkill)
             }
 
-            ToolbarSpacer(.fixed)
+            if #available(macOS 26.0, *) {
+                ToolbarSpacer(.fixed)
+            }
+
         }
 
         ToolbarItem(id: "open") {
             openFolderItem
         }
 
-        ToolbarSpacer(.fixed)
+        if #available(macOS 26.0, *) {
+            ToolbarSpacer(.fixed)
+        }
 
         ToolbarItem(id: "add") {
             Menu {


### PR DESCRIPTION
Adds macOS 15 support to fix #17

I am waiting to update because I don't like Liquid Glass and my workflows are still on Sequioa.