### PR TITLE
fix(skills): follow symlinks when scanning roots

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             ]),
         .testTarget(
             name: "CodexSkillManagerTests",
-            dependencies: [],
+            dependencies: ["CodexSkillManager"],
             path: "Tests/CodexSkillManagerTests",
             swiftSettings: [
                 .unsafeFlags(["-strict-concurrency=complete"]),

--- a/Sources/CodexSkillManager/Workers/SkillFileWorker.swift
+++ b/Sources/CodexSkillManager/Workers/SkillFileWorker.swift
@@ -86,12 +86,16 @@ actor SkillFileWorker {
 
     func scanSkills(at baseURL: URL, storageKey: String) throws -> [ScannedSkillData] {
         let fileManager = FileManager.default
-        guard fileManager.fileExists(atPath: baseURL.path) else {
+
+        // Directory symlinks can fail URL-based enumeration on macOS.
+        let directoryURL = baseURL.resolvingSymlinksInPath()
+
+        guard fileManager.fileExists(atPath: directoryURL.path) else {
             return []
         }
 
         let items = try fileManager.contentsOfDirectory(
-            at: baseURL,
+            at: directoryURL,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]
         )

--- a/Tests/CodexSkillManagerTests/SymlinkScanTests.swift
+++ b/Tests/CodexSkillManagerTests/SymlinkScanTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import CodexSkillManager
+
+@Suite("Symlink Scan")
+struct SymlinkScanTests {
+    @Test("scanSkills follows directory symlinks")
+    func scanSkillsFollowsDirectorySymlinks() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        let realRoot = tempRoot.appendingPathComponent("real")
+        let symlinkRoot = tempRoot.appendingPathComponent("link")
+
+        try fileManager.createDirectory(at: realRoot, withIntermediateDirectories: true)
+
+        let skillRoot = realRoot.appendingPathComponent("my-skill")
+        try fileManager.createDirectory(at: skillRoot, withIntermediateDirectories: true)
+        try "# My Skill\n".write(
+            to: skillRoot.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try fileManager.createSymbolicLink(at: symlinkRoot, withDestinationURL: realRoot)
+
+        let worker = SkillFileWorker()
+        let scanned = try await worker.scanSkills(at: symlinkRoot, storageKey: "test")
+
+        #expect(scanned.count == 1)
+        #expect(scanned.first?.name == "my-skill")
+    }
+}


### PR DESCRIPTION
## Summary
- Resolve directory symlinks before enumerating skills roots.
- Add regression test for scanning a symlinked skills root.

## Motivation
Some users point platform skill roots at a shared folder via symlinks (e.g. `~/.codex/skills/public -> ~/.agents/skills`). On macOS, URL-based directory enumeration can fail on directory symlinks, causing scans to return empty.

## Testing
- `swift test`