### PR TITLE
feat: add symlink import functionality

### DIFF
--- a/Sources/CodexSkillManager/Skills/Import/ImportSkillView.swift
+++ b/Sources/CodexSkillManager/Skills/Import/ImportSkillView.swift
@@ -18,6 +18,7 @@ struct ImportSkillView: View {
     @State private var status: Status = .idle
     @State private var errorMessage: String = ""
     @State private var installTargets: Set<SkillPlatform> = [.codex]
+    @State private var useSymlink: Bool = true
     private let importWorker = SkillImportWorker()
 
     private enum Status {
@@ -125,6 +126,18 @@ struct ImportSkillView: View {
                         installedTargets: [],
                         selection: $installTargets
                     )
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle("Import using symlink", isOn: $useSymlink)
+                            .disabled(candidate.temporaryRoot != nil)
+
+                        if candidate.temporaryRoot != nil {
+                            Text("Symlinks cannot be used with zip files (will be copied instead)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
                     Markdown(candidate.markdown)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -247,7 +260,7 @@ struct ImportSkillView: View {
                 markdown: candidate.markdown,
                 temporaryRoot: candidate.temporaryRoot
             )
-            try await importWorker.importCandidate(payload, destinations: destinations, shouldMove: shouldMove)
+            try await importWorker.importCandidate(payload, destinations: destinations, shouldMove: shouldMove, useSymlink: useSymlink)
 
             await store.loadSkills()
             status = .imported

--- a/Sources/CodexSkillManager/Workers/SkillImportWorker.swift
+++ b/Sources/CodexSkillManager/Workers/SkillImportWorker.swift
@@ -57,7 +57,8 @@ actor SkillImportWorker {
     func importCandidate(
         _ candidate: ImportCandidatePayload,
         destinations: [SkillFileWorker.InstallDestination],
-        shouldMove: Bool
+        shouldMove: Bool,
+        useSymlink: Bool
     ) throws {
         let fileManager = FileManager.default
 
@@ -71,7 +72,9 @@ actor SkillImportWorker {
                 try fileManager.removeItem(at: finalURL)
             }
 
-            if shouldMove {
+            if useSymlink {
+                try fileManager.createSymbolicLink(at: finalURL, withDestinationURL: candidate.rootURL)
+            } else if shouldMove {
                 try fileManager.moveItem(at: candidate.rootURL, to: finalURL)
             } else {
                 try fileManager.copyItem(at: candidate.rootURL, to: finalURL)

--- a/Tests/CodexSkillManagerTests/AddCustomPathTests.swift
+++ b/Tests/CodexSkillManagerTests/AddCustomPathTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+
+@testable import CodexSkillManager
+
+@Suite("Add Custom Path Workflow Tests")
+struct AddCustomPathTests {
+
+    @MainActor
+    @Test("AddCustomPath does not modify source directory")
+    func customPathDoesNotModifySource() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create a custom path directory with a skill
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        let skillFolder = tempRoot.appendingPathComponent("test-skill")
+        try fileManager.createDirectory(at: skillFolder, withIntermediateDirectories: true)
+
+        let skillMd = """
+        ---
+        name: Test Skill
+        description: A test skill for custom path testing
+        ---
+
+        # Test Skill
+        This is a test skill.
+        """
+        try skillMd.write(
+            to: skillFolder.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create a marker file to verify nothing is moved/copied/symlinked
+        let markerFile = skillFolder.appendingPathComponent("marker.txt")
+        try "original".write(to: markerFile, atomically: true, encoding: .utf8)
+
+        // Add custom path using SkillStore
+        let customPathStore = CustomPathStore()
+        let store = SkillStore(customPathStore: customPathStore)
+
+        try store.addCustomPath(tempRoot)
+
+        // Verify source directory is unchanged
+        #expect(fileManager.fileExists(atPath: skillFolder.path))
+        #expect(fileManager.fileExists(atPath: markerFile.path))
+
+        let markerContent = try String(contentsOf: markerFile, encoding: .utf8)
+        #expect(markerContent == "original")
+
+        // Verify no symlinks were created
+        let values = try? skillFolder.resourceValues(forKeys: [.isSymbolicLinkKey])
+        #expect(values?.isSymbolicLink != true)
+    }
+
+    @MainActor
+    @Test("Custom path skills are discovered via scanning")
+    func customPathSkillsDiscoveredByScanning() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create custom path with platform subdirectory structure
+        // Custom paths scan for .claude/skills, .codex/skills, etc.
+        let skillsDir = tempRoot.appendingPathComponent(".claude/skills")
+        try fileManager.createDirectory(at: skillsDir, withIntermediateDirectories: true)
+
+        for i in 1...3 {
+            let skillFolder = skillsDir.appendingPathComponent("skill-\(i)")
+            try fileManager.createDirectory(at: skillFolder, withIntermediateDirectories: true)
+
+            let skillMd = """
+            ---
+            name: Skill \(i)
+            description: Test skill number \(i)
+            ---
+
+            # Skill \(i)
+            """
+            try skillMd.write(
+                to: skillFolder.appendingPathComponent("SKILL.md"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        // Add custom path
+        let customPathStore = CustomPathStore()
+        let store = SkillStore(customPathStore: customPathStore)
+
+        try store.addCustomPath(tempRoot)
+
+        // Load skills (which triggers scanning)
+        await store.loadSkills()
+
+        // Verify skills were discovered
+        let customPathSkills = store.skills.filter { $0.customPath != nil }
+        #expect(customPathSkills.count == 3)
+
+        // Verify skill names
+        let skillNames = Set(customPathSkills.map { $0.name })
+        #expect(skillNames.contains("skill-1"))
+        #expect(skillNames.contains("skill-2"))
+        #expect(skillNames.contains("skill-3"))
+    }
+
+    @MainActor
+    @Test("Custom path does not create files in system directories")
+    func customPathNoSystemDirectoryModification() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create custom path
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        let skillFolder = tempRoot.appendingPathComponent("test-skill")
+        try fileManager.createDirectory(at: skillFolder, withIntermediateDirectories: true)
+
+        try "# Test\n".write(
+            to: skillFolder.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Get skill platform directories before adding custom path
+        let platformRoots = SkillPlatform.allCases.flatMap { $0.rootURLs }
+        var beforeContents: [URL: [String]] = [:]
+
+        for rootURL in platformRoots {
+            if fileManager.fileExists(atPath: rootURL.path) {
+                let contents = (try? fileManager.contentsOfDirectory(
+                    at: rootURL,
+                    includingPropertiesForKeys: nil,
+                    options: []
+                )) ?? []
+                beforeContents[rootURL] = contents.map { $0.lastPathComponent }
+            }
+        }
+
+        // Add custom path
+        let customPathStore = CustomPathStore()
+        let store = SkillStore(customPathStore: customPathStore)
+
+        try store.addCustomPath(tempRoot)
+        await store.loadSkills()
+
+        // Verify platform directories are unchanged
+        for rootURL in platformRoots {
+            if let beforeList = beforeContents[rootURL] {
+                let afterContents = (try? fileManager.contentsOfDirectory(
+                    at: rootURL,
+                    includingPropertiesForKeys: nil,
+                    options: []
+                )) ?? []
+                let afterList = afterContents.map { $0.lastPathComponent }
+
+                #expect(Set(beforeList) == Set(afterList),
+                       "Platform directory \(rootURL.path) was modified")
+            }
+        }
+    }
+}

--- a/Tests/CodexSkillManagerTests/SkillImportWorkerTests.swift
+++ b/Tests/CodexSkillManagerTests/SkillImportWorkerTests.swift
@@ -1,0 +1,399 @@
+import Foundation
+import Testing
+
+@testable import CodexSkillManager
+
+@Suite("Skill Import Worker Tests")
+struct SkillImportWorkerTests {
+
+    @Test("Creates symlink when useSymlink is true")
+    func createsSymlinkWhenEnabled() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create source skill folder
+        let sourceSkill = tempRoot.appendingPathComponent("source-skill")
+        try fileManager.createDirectory(at: sourceSkill, withIntermediateDirectories: true)
+
+        let skillMd = """
+        ---
+        name: Source Skill
+        description: A source skill for symlink testing
+        ---
+
+        # Source Skill
+        """
+        try skillMd.write(
+            to: sourceSkill.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create destination directory
+        let destinationRoot = tempRoot.appendingPathComponent("destination")
+        try fileManager.createDirectory(at: destinationRoot, withIntermediateDirectories: true)
+
+        // Create import candidate
+        let candidate = SkillImportWorker.ImportCandidatePayload(
+            rootURL: sourceSkill,
+            skillFileURL: sourceSkill.appendingPathComponent("SKILL.md"),
+            skillName: "source-skill",
+            markdown: skillMd,
+            temporaryRoot: nil
+        )
+
+        let destination = SkillFileWorker.InstallDestination(
+            rootURL: destinationRoot,
+            storageKey: "test"
+        )
+
+        // Import with symlink
+        let worker = SkillImportWorker()
+        try await worker.importCandidate(
+            candidate,
+            destinations: [destination],
+            shouldMove: false,
+            useSymlink: true
+        )
+
+        // Verify symlink created
+        let symlinkURL = destinationRoot.appendingPathComponent("source-skill")
+        #expect(fileManager.fileExists(atPath: symlinkURL.path))
+
+        let values = try symlinkURL.resourceValues(forKeys: [.isSymbolicLinkKey])
+        #expect(values.isSymbolicLink == true)
+
+        // Verify symlink points to source
+        let symlinkDestination = try fileManager.destinationOfSymbolicLink(atPath: symlinkURL.path)
+        #expect(symlinkDestination == sourceSkill.path)
+
+        // Verify source still exists
+        #expect(fileManager.fileExists(atPath: sourceSkill.path))
+    }
+
+    @Test("Moves files when useSymlink is false and shouldMove is true")
+    func movesWhenSymlinkDisabled() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create source skill folder
+        let sourceSkill = tempRoot.appendingPathComponent("move-skill")
+        try fileManager.createDirectory(at: sourceSkill, withIntermediateDirectories: true)
+
+        let skillMd = "# Move Skill\n"
+        try skillMd.write(
+            to: sourceSkill.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create destination directory
+        let destinationRoot = tempRoot.appendingPathComponent("destination")
+        try fileManager.createDirectory(at: destinationRoot, withIntermediateDirectories: true)
+
+        // Create import candidate
+        let candidate = SkillImportWorker.ImportCandidatePayload(
+            rootURL: sourceSkill,
+            skillFileURL: sourceSkill.appendingPathComponent("SKILL.md"),
+            skillName: "move-skill",
+            markdown: skillMd,
+            temporaryRoot: nil
+        )
+
+        let destination = SkillFileWorker.InstallDestination(
+            rootURL: destinationRoot,
+            storageKey: "test"
+        )
+
+        // Import with move
+        let worker = SkillImportWorker()
+        try await worker.importCandidate(
+            candidate,
+            destinations: [destination],
+            shouldMove: true,
+            useSymlink: false
+        )
+
+        // Verify files moved to destination
+        let movedURL = destinationRoot.appendingPathComponent("move-skill")
+        #expect(fileManager.fileExists(atPath: movedURL.path))
+
+        // Verify it's a real directory, not a symlink
+        let values = try? movedURL.resourceValues(forKeys: [.isSymbolicLinkKey])
+        #expect(values?.isSymbolicLink != true)
+
+        // Verify source folder deleted
+        #expect(!fileManager.fileExists(atPath: sourceSkill.path))
+    }
+
+    @Test("Copies files when useSymlink is false and shouldMove is false")
+    func copiesWhenSymlinkDisabled() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create source skill folder
+        let sourceSkill = tempRoot.appendingPathComponent("copy-skill")
+        try fileManager.createDirectory(at: sourceSkill, withIntermediateDirectories: true)
+
+        let skillMd = "# Copy Skill\n"
+        try skillMd.write(
+            to: sourceSkill.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create destination directory
+        let destinationRoot = tempRoot.appendingPathComponent("destination")
+        try fileManager.createDirectory(at: destinationRoot, withIntermediateDirectories: true)
+
+        // Create import candidate
+        let candidate = SkillImportWorker.ImportCandidatePayload(
+            rootURL: sourceSkill,
+            skillFileURL: sourceSkill.appendingPathComponent("SKILL.md"),
+            skillName: "copy-skill",
+            markdown: skillMd,
+            temporaryRoot: nil
+        )
+
+        let destination = SkillFileWorker.InstallDestination(
+            rootURL: destinationRoot,
+            storageKey: "test"
+        )
+
+        // Import with copy
+        let worker = SkillImportWorker()
+        try await worker.importCandidate(
+            candidate,
+            destinations: [destination],
+            shouldMove: false,
+            useSymlink: false
+        )
+
+        // Verify files copied to destination
+        let copiedURL = destinationRoot.appendingPathComponent("copy-skill")
+        #expect(fileManager.fileExists(atPath: copiedURL.path))
+
+        // Verify it's a real directory, not a symlink
+        let values = try? copiedURL.resourceValues(forKeys: [.isSymbolicLinkKey])
+        #expect(values?.isSymbolicLink != true)
+
+        // Verify source folder still exists
+        #expect(fileManager.fileExists(atPath: sourceSkill.path))
+
+        // Verify both have SKILL.md
+        #expect(fileManager.fileExists(atPath: sourceSkill.appendingPathComponent("SKILL.md").path))
+        #expect(fileManager.fileExists(atPath: copiedURL.appendingPathComponent("SKILL.md").path))
+    }
+
+    @Test("Creates multiple symlinks for multiple destinations")
+    func multipleDestinationSymlinks() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create source skill folder
+        let sourceSkill = tempRoot.appendingPathComponent("multi-skill")
+        try fileManager.createDirectory(at: sourceSkill, withIntermediateDirectories: true)
+
+        let skillMd = "# Multi Skill\n"
+        try skillMd.write(
+            to: sourceSkill.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create multiple destination directories
+        let destination1 = tempRoot.appendingPathComponent("dest1")
+        let destination2 = tempRoot.appendingPathComponent("dest2")
+        let destination3 = tempRoot.appendingPathComponent("dest3")
+
+        try fileManager.createDirectory(at: destination1, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: destination2, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: destination3, withIntermediateDirectories: true)
+
+        // Create import candidate
+        let candidate = SkillImportWorker.ImportCandidatePayload(
+            rootURL: sourceSkill,
+            skillFileURL: sourceSkill.appendingPathComponent("SKILL.md"),
+            skillName: "multi-skill",
+            markdown: skillMd,
+            temporaryRoot: nil
+        )
+
+        let destinations = [
+            SkillFileWorker.InstallDestination(rootURL: destination1, storageKey: "test1"),
+            SkillFileWorker.InstallDestination(rootURL: destination2, storageKey: "test2"),
+            SkillFileWorker.InstallDestination(rootURL: destination3, storageKey: "test3")
+        ]
+
+        // Import with symlinks to multiple destinations
+        let worker = SkillImportWorker()
+        try await worker.importCandidate(
+            candidate,
+            destinations: destinations,
+            shouldMove: false,
+            useSymlink: true
+        )
+
+        // Verify all three symlinks created
+        let symlink1 = destination1.appendingPathComponent("multi-skill")
+        let symlink2 = destination2.appendingPathComponent("multi-skill")
+        let symlink3 = destination3.appendingPathComponent("multi-skill")
+
+        #expect(fileManager.fileExists(atPath: symlink1.path))
+        #expect(fileManager.fileExists(atPath: symlink2.path))
+        #expect(fileManager.fileExists(atPath: symlink3.path))
+
+        // Verify all are symlinks
+        let values1 = try symlink1.resourceValues(forKeys: [.isSymbolicLinkKey])
+        let values2 = try symlink2.resourceValues(forKeys: [.isSymbolicLinkKey])
+        let values3 = try symlink3.resourceValues(forKeys: [.isSymbolicLinkKey])
+
+        #expect(values1.isSymbolicLink == true)
+        #expect(values2.isSymbolicLink == true)
+        #expect(values3.isSymbolicLink == true)
+
+        // Verify all point to same source
+        let dest1 = try fileManager.destinationOfSymbolicLink(atPath: symlink1.path)
+        let dest2 = try fileManager.destinationOfSymbolicLink(atPath: symlink2.path)
+        let dest3 = try fileManager.destinationOfSymbolicLink(atPath: symlink3.path)
+
+        #expect(dest1 == sourceSkill.path)
+        #expect(dest2 == sourceSkill.path)
+        #expect(dest3 == sourceSkill.path)
+    }
+
+    @Test("Creates numbered version when skill already exists")
+    func createsNumberedVersionWhenExists() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create two source directories for the same skill name
+        let sourceV1 = tempRoot.appendingPathComponent("source-v1/my-skill")
+        let sourceV2 = tempRoot.appendingPathComponent("source-v2/my-skill")
+
+        try fileManager.createDirectory(at: sourceV1, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: sourceV2, withIntermediateDirectories: true)
+
+        try "# Version 1\n".write(
+            to: sourceV1.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "# Version 2\n".write(
+            to: sourceV2.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create destination directory
+        let destinationRoot = tempRoot.appendingPathComponent("destination")
+        try fileManager.createDirectory(at: destinationRoot, withIntermediateDirectories: true)
+
+        let destination = SkillFileWorker.InstallDestination(
+            rootURL: destinationRoot,
+            storageKey: "test"
+        )
+
+        // Import version 1
+        let candidateV1 = SkillImportWorker.ImportCandidatePayload(
+            rootURL: sourceV1,
+            skillFileURL: sourceV1.appendingPathComponent("SKILL.md"),
+            skillName: "my-skill",
+            markdown: "# Version 1\n",
+            temporaryRoot: nil
+        )
+
+        let worker = SkillImportWorker()
+        try await worker.importCandidate(
+            candidateV1,
+            destinations: [destination],
+            shouldMove: false,
+            useSymlink: true
+        )
+
+        // Verify first symlink created
+        let symlink1 = destinationRoot.appendingPathComponent("my-skill")
+        #expect(fileManager.fileExists(atPath: symlink1.path))
+
+        // Import version 2 with same name (should create numbered version)
+        let candidateV2 = SkillImportWorker.ImportCandidatePayload(
+            rootURL: sourceV2,
+            skillFileURL: sourceV2.appendingPathComponent("SKILL.md"),
+            skillName: "my-skill",
+            markdown: "# Version 2\n",
+            temporaryRoot: nil
+        )
+
+        try await worker.importCandidate(
+            candidateV2,
+            destinations: [destination],
+            shouldMove: false,
+            useSymlink: true
+        )
+
+        // Verify numbered version created (my-skill-1)
+        let symlink2 = destinationRoot.appendingPathComponent("my-skill-1")
+        #expect(fileManager.fileExists(atPath: symlink2.path))
+
+        // Verify both symlinks point to their respective sources
+        let dest1 = try fileManager.destinationOfSymbolicLink(atPath: symlink1.path)
+        let dest2 = try fileManager.destinationOfSymbolicLink(atPath: symlink2.path)
+
+        #expect(dest1 == sourceV1.path)
+        #expect(dest2 == sourceV2.path)
+    }
+
+    @Test("Validates folder correctly finds SKILL.md")
+    func validateFolderFindsSkillMd() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create skill folder
+        let skillFolder = tempRoot.appendingPathComponent("test-skill")
+        try fileManager.createDirectory(at: skillFolder, withIntermediateDirectories: true)
+
+        let skillMd = """
+        ---
+        name: Test Skill
+        ---
+
+        # Test Skill
+        """
+        try skillMd.write(
+            to: skillFolder.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Validate folder
+        let worker = SkillImportWorker()
+        let candidate = await worker.validateFolder(skillFolder)
+
+        #expect(candidate != nil)
+        #expect(candidate?.skillName == "test-skill")
+        #expect(candidate?.rootURL == skillFolder)
+        #expect(candidate?.markdown.contains("# Test Skill") == true)
+    }
+
+    @Test("Validates folder returns nil for invalid folder")
+    func validateFolderReturnsNilForInvalid() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create folder without SKILL.md
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+
+        // Validate folder
+        let worker = SkillImportWorker()
+        let candidate = await worker.validateFolder(tempRoot)
+
+        #expect(candidate == nil)
+    }
+}

--- a/Tests/CodexSkillManagerTests/SymlinkScanTests.swift
+++ b/Tests/CodexSkillManagerTests/SymlinkScanTests.swift
@@ -32,4 +32,243 @@ struct SymlinkScanTests {
         #expect(scanned.count == 1)
         #expect(scanned.first?.name == "my-skill")
     }
+
+    @MainActor
+    @Test("Scanned symlinked skills have correct metadata")
+    func symlinkSkillMetadataExtraction() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create real skill with frontmatter
+        let realRoot = tempRoot.appendingPathComponent("real")
+        let skillRoot = realRoot.appendingPathComponent("metadata-skill")
+        try fileManager.createDirectory(at: skillRoot, withIntermediateDirectories: true)
+
+        let skillMd = """
+        ---
+        name: Metadata Test Skill
+        description: A skill for testing metadata extraction through symlinks
+        ---
+
+        # Metadata Test Skill
+        This skill tests metadata extraction.
+        """
+        try skillMd.write(
+            to: skillRoot.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create symlink to skill
+        let symlinkRoot = tempRoot.appendingPathComponent("link")
+        try fileManager.createDirectory(at: symlinkRoot, withIntermediateDirectories: true)
+        let symlinkSkill = symlinkRoot.appendingPathComponent("metadata-skill")
+        try fileManager.createSymbolicLink(at: symlinkSkill, withDestinationURL: skillRoot)
+
+        // Scan through symlink
+        let worker = SkillFileWorker()
+        let scanned = try await worker.scanSkills(at: symlinkRoot, storageKey: "test")
+
+        #expect(scanned.count == 1)
+        #expect(scanned.first?.name == "metadata-skill")
+        #expect(scanned.first?.displayName == "Metadata Test Skill")
+        #expect(scanned.first?.description == "A skill for testing metadata extraction through symlinks")
+    }
+
+    @MainActor
+    @Test("Symlinked skills count references correctly")
+    func symlinkReferencesCounting() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create skill with references
+        let skillRoot = tempRoot.appendingPathComponent("skill-with-refs")
+        try fileManager.createDirectory(at: skillRoot, withIntermediateDirectories: true)
+
+        let skillMd = "# Skill with References\n"
+        try skillMd.write(
+            to: skillRoot.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create references directory with markdown files
+        let refsDir = skillRoot.appendingPathComponent("references")
+        try fileManager.createDirectory(at: refsDir, withIntermediateDirectories: true)
+
+        try "# Reference 1".write(to: refsDir.appendingPathComponent("ref1.md"), atomically: true, encoding: .utf8)
+        try "# Reference 2".write(to: refsDir.appendingPathComponent("ref2.md"), atomically: true, encoding: .utf8)
+        try "# Reference 3".write(to: refsDir.appendingPathComponent("ref3.md"), atomically: true, encoding: .utf8)
+
+        // Create symlink to skill
+        let symlinkRoot = tempRoot.appendingPathComponent("link")
+        try fileManager.createDirectory(at: symlinkRoot, withIntermediateDirectories: true)
+        let symlinkSkill = symlinkRoot.appendingPathComponent("skill-with-refs")
+        try fileManager.createSymbolicLink(at: symlinkSkill, withDestinationURL: skillRoot)
+
+        // Scan through symlink
+        let worker = SkillFileWorker()
+        let scanned = try await worker.scanSkills(at: symlinkRoot, storageKey: "test")
+
+        #expect(scanned.count == 1)
+
+        guard let skill = scanned.first else {
+            throw NSError(domain: "Test", code: 1, userInfo: [NSLocalizedDescriptionKey: "No skill found"])
+        }
+
+        #expect(skill.references.count == 3)
+
+        let refNames = skill.references.map { $0.name }
+        #expect(refNames.contains("Ref1"))
+        #expect(refNames.contains("Ref2"))
+        #expect(refNames.contains("Ref3"))
+    }
+
+    @MainActor
+    @Test("Symlinked skills count assets/scripts/templates")
+    func symlinkStatsCounting() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create skill with assets, scripts, and templates
+        let skillRoot = tempRoot.appendingPathComponent("full-skill")
+        try fileManager.createDirectory(at: skillRoot, withIntermediateDirectories: true)
+
+        let skillMd = "# Full Skill\n"
+        try skillMd.write(
+            to: skillRoot.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create assets directory with files
+        let assetsDir = skillRoot.appendingPathComponent("assets")
+        try fileManager.createDirectory(at: assetsDir, withIntermediateDirectories: true)
+        try "asset1".write(to: assetsDir.appendingPathComponent("logo.png"), atomically: true, encoding: .utf8)
+        try "asset2".write(to: assetsDir.appendingPathComponent("icon.svg"), atomically: true, encoding: .utf8)
+
+        // Create scripts directory with files
+        let scriptsDir = skillRoot.appendingPathComponent("scripts")
+        try fileManager.createDirectory(at: scriptsDir, withIntermediateDirectories: true)
+        try "#!/bin/bash\n".write(to: scriptsDir.appendingPathComponent("setup.sh"), atomically: true, encoding: .utf8)
+        try "#!/bin/bash\n".write(to: scriptsDir.appendingPathComponent("build.sh"), atomically: true, encoding: .utf8)
+        try "#!/bin/bash\n".write(to: scriptsDir.appendingPathComponent("deploy.sh"), atomically: true, encoding: .utf8)
+
+        // Create templates directory with files
+        let templatesDir = skillRoot.appendingPathComponent("templates")
+        try fileManager.createDirectory(at: templatesDir, withIntermediateDirectories: true)
+        try "template1".write(to: templatesDir.appendingPathComponent("config.yml"), atomically: true, encoding: .utf8)
+
+        // Create symlink to skill
+        let symlinkRoot = tempRoot.appendingPathComponent("link")
+        try fileManager.createDirectory(at: symlinkRoot, withIntermediateDirectories: true)
+        let symlinkSkill = symlinkRoot.appendingPathComponent("full-skill")
+        try fileManager.createSymbolicLink(at: symlinkSkill, withDestinationURL: skillRoot)
+
+        // Scan through symlink
+        let worker = SkillFileWorker()
+        let scanned = try await worker.scanSkills(at: symlinkRoot, storageKey: "test")
+
+        #expect(scanned.count == 1)
+
+        guard let skill = scanned.first else {
+            throw NSError(domain: "Test", code: 1, userInfo: [NSLocalizedDescriptionKey: "No skill found"])
+        }
+
+        let stats = skill.stats
+        let assets = stats.assets
+        let scripts = stats.scripts
+        let templates = stats.templates
+        #expect(assets == 2)
+        #expect(scripts == 3)
+        #expect(templates == 1)
+    }
+
+    @MainActor
+    @Test("Symlinked skills in nested structure")
+    func symlinkInNestedStructure() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create real skill in nested directory
+        let realRoot = tempRoot.appendingPathComponent("real/deeply/nested")
+        try fileManager.createDirectory(at: realRoot, withIntermediateDirectories: true)
+
+        let skillRoot = realRoot.appendingPathComponent("nested-skill")
+        try fileManager.createDirectory(at: skillRoot, withIntermediateDirectories: true)
+
+        let skillMd = """
+        ---
+        name: Nested Skill
+        ---
+
+        # Nested Skill
+        """
+        try skillMd.write(
+            to: skillRoot.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create symlink in flat directory
+        let linkRoot = tempRoot.appendingPathComponent("links")
+        try fileManager.createDirectory(at: linkRoot, withIntermediateDirectories: true)
+        let symlinkSkill = linkRoot.appendingPathComponent("nested-skill")
+        try fileManager.createSymbolicLink(at: symlinkSkill, withDestinationURL: skillRoot)
+
+        // Scan through symlink
+        let worker = SkillFileWorker()
+        let scanned = try await worker.scanSkills(at: linkRoot, storageKey: "test")
+
+        #expect(scanned.count == 1)
+        #expect(scanned.first?.name == "nested-skill")
+        #expect(scanned.first?.displayName == "Nested Skill")
+    }
+
+    @MainActor
+    @Test("Multiple symlinked skills are all discovered")
+    func multipleSymlinkedSkills() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        // Create multiple real skills
+        let realRoot = tempRoot.appendingPathComponent("real")
+        try fileManager.createDirectory(at: realRoot, withIntermediateDirectories: true)
+
+        for i in 1...5 {
+            let skillRoot = realRoot.appendingPathComponent("skill-\(i)")
+            try fileManager.createDirectory(at: skillRoot, withIntermediateDirectories: true)
+            try "# Skill \(i)\n".write(
+                to: skillRoot.appendingPathComponent("SKILL.md"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        // Create symlink directory with links to all skills
+        let linkRoot = tempRoot.appendingPathComponent("links")
+        try fileManager.createDirectory(at: linkRoot, withIntermediateDirectories: true)
+
+        for i in 1...5 {
+            let sourceSkill = realRoot.appendingPathComponent("skill-\(i)")
+            let linkSkill = linkRoot.appendingPathComponent("skill-\(i)")
+            try fileManager.createSymbolicLink(at: linkSkill, withDestinationURL: sourceSkill)
+        }
+
+        // Scan symlink directory
+        let worker = SkillFileWorker()
+        let scanned = try await worker.scanSkills(at: linkRoot, storageKey: "test")
+
+        #expect(scanned.count == 5)
+
+        let skillNames = Set(scanned.map { $0.name })
+        for i in 1...5 {
+            #expect(skillNames.contains("skill-\(i)"))
+        }
+    }
 }


### PR DESCRIPTION
# Add Symlink Import for Skills

<img width="719" height="566" alt="Screenshot 2026-01-18 at 11 11 11 PM" src="https://github.com/user-attachments/assets/cb4b466d-4d69-4a80-8ff1-4c4e96ca0948" />

## Overview
Adds ability to import skills using symlinks instead of moving or copying files, allowing users to keep their skills in their original location while making them available in platform skill directories.

 ## Feature: Symlink Import Option

 When importing skills, users can now choose to create a symlink instead of moving/copying:
 - **Symlink (non-destructive):** Original files stay in place, symlink created in skill directory

  ### Why Symlinks?
  - Keep skills in version-controlled repositories
  - Manage skills from custom locations without duplication
  - Non-destructive - original files remain untouched
  - Single source of truth - edit in original location

 ## Use Case Example

 **Managing Custom Skills in Your Own Repository:**

  ```bash
  # Your skill repository
  ~/code/my-skills/
  ├── data-analysis/
  │   ├── SKILL.md
  │   ├── references/
  │   └── scripts/
  └── code-review/
      ├── SKILL.md
      └── templates/

 ~/.claude/skills/data-analysis → ~/code/my-skills/data-analysis
 ~/.codex/skills/data-analysis → ~/code/my-skills/data-analysis
```