### PR TITLE
chore: Rename Clawdhub to Clawhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 ![image](image.png)
 
-Codex Skill Manager is a macOS SwiftUI app built with SwiftPM (no Xcode project). It manages local skills for Codex and Claude Code, renders each `SKILL.md`, and lets you browse remote skills from Clawdhub.
+Codex Skill Manager is a macOS SwiftUI app built with SwiftPM (no Xcode project). It manages local skills for Codex and Claude Code, renders each `SKILL.md`, and lets you browse remote skills from Molthub.
 
 ## Features
 - Browse local skills from `~/.codex/skills`, `~/.codex/skills/public`, and `~/.claude/skills`
 - Render `SKILL.md` with Markdown, plus inline reference previews
 - Import skills from a folder or zip
 - Delete skills from the sidebar
-- Browse Clawdhub skills with search + latest drops
+- Browse Molthub skills with search + latest drops
 - Download remote skills into Codex and/or Claude Code
-- Show Clawdhub author info in the detail view
+- Show Molthub author info in the detail view
 - Visual tags for installed status (Codex/Claude) and versions
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 ![image](image.png)
 
-Codex Skill Manager is a macOS SwiftUI app built with SwiftPM (no Xcode project). It manages local skills for Codex and Claude Code, renders each `SKILL.md`, and lets you browse remote skills from Molthub.
+Codex Skill Manager is a macOS SwiftUI app built with SwiftPM (no Xcode project). It manages local skills for Codex and Claude Code, renders each `SKILL.md`, and lets you browse remote skills from Clawhub.
 
 ## Features
 - Browse local skills from `~/.codex/skills`, `~/.codex/skills/public`, and `~/.claude/skills`
 - Render `SKILL.md` with Markdown, plus inline reference previews
 - Import skills from a folder or zip
 - Delete skills from the sidebar
-- Browse Molthub skills with search + latest drops
+- Browse Clawhub skills with search + latest drops
 - Download remote skills into Codex and/or Claude Code
-- Show Molthub author info in the detail view
+- Show Clawhub author info in the detail view
 - Visual tags for installed status (Codex/Claude) and versions
 
 ## Requirements
@@ -31,4 +31,4 @@ swift run CodexSkillManager
 
 ## Credits
 - Markdown rendering via https://github.com/gonzalezreal/swift-markdown-ui
-- Remote skill catalog via https://clawdhub.com
+- Remote skill catalog via https://clawhub.ai

--- a/Sources/CodexSkillManager/Skills/Local/Detail/SkillMarkdownView.swift
+++ b/Sources/CodexSkillManager/Skills/Local/Detail/SkillMarkdownView.swift
@@ -10,7 +10,7 @@ struct SkillMarkdownView: View {
 
     @State private var needsPublish = false
     @State private var isOwned = false
-    @State private var clawdhubOrigin: SkillFileWorker.ClawdhubOrigin?
+    @State private var molthubOrigin: SkillFileWorker.MolthubOrigin?
     @State private var installedVersion: String?
     @State private var latestVersion: String?
     @State private var updateAvailable = false
@@ -35,7 +35,7 @@ struct SkillMarkdownView: View {
             VStack(alignment: .leading, spacing: 16) {
                 if isOwned {
                     publishSection
-                } else if clawdhubOrigin != nil {
+                } else if molthubOrigin != nil {
                     installSection
                 }
                 Markdown(markdown)
@@ -56,14 +56,14 @@ struct SkillMarkdownView: View {
         .navigationTitle(skill.displayName)
         .navigationSubtitle(skill.folderPath)
         .toolbar {
-            if clawdhubURL != nil {
+            if molthubURL != nil {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
-                        openClawdhubURL()
+                        openMolthubURL()
                     } label: {
                         Image(systemName: "globe")
                     }
-                    .help("Open on Clawdhub")
+                    .help("Open on Molthub")
                 }
             }
         }
@@ -104,7 +104,7 @@ struct SkillMarkdownView: View {
 
     private var publishHeader: some View {
         HStack(spacing: 8) {
-            Text("Clawdhub")
+            Text("Molthub")
                 .font(.headline)
             Spacer()
             if isCheckingPublish || isCheckingCli {
@@ -117,7 +117,7 @@ struct SkillMarkdownView: View {
     @ViewBuilder
     private var publishContent: some View {
         if isCheckingCli || isCheckingPublish {
-            Text("Checking Clawdhub status…")
+            Text("Checking Molthub status…")
                 .foregroundStyle(.secondary)
         } else if !cliStatus.isInstalled {
             publishInstallContent
@@ -130,7 +130,7 @@ struct SkillMarkdownView: View {
 
     private var publishInstallContent: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Install Bun to run the Clawdhub CLI.")
+            Text("Install Bun to run the Molthub CLI.")
                 .foregroundStyle(.secondary)
 
             Button("Install Bun") {
@@ -142,7 +142,7 @@ struct SkillMarkdownView: View {
 
     private var publishLoginContent: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Run bunx clawdhub@latest login in Terminal, then check again.")
+            Text("Run bunx molthub@latest login in your Terminal, then check again.")
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 12) {
@@ -173,12 +173,12 @@ struct SkillMarkdownView: View {
                 Text(needsPublish ? "Changes detected. Publish an update." : "No unpublished changes.")
                     .foregroundStyle(.secondary)
             } else {
-                Text("Not yet published on Clawdhub.")
+                Text("Not yet published on Molthub.")
                     .foregroundStyle(.secondary)
             }
 
             HStack(spacing: 12) {
-                Button(publishedVersion == nil ? "Publish to Clawdhub" : "Update on Clawdhub") {
+                Button(publishedVersion == nil ? "Publish to Molthub" : "Update on Molthub") {
                     publishSheetSkill = skill
                 }
                 .buttonStyle(.borderedProminent)
@@ -205,7 +205,7 @@ struct SkillMarkdownView: View {
     @ViewBuilder
     private var installContent: some View {
         if isCheckingPublish {
-            Text("Checking Clawdhub status…")
+            Text("Checking Molthub status…")
                 .foregroundStyle(.secondary)
         } else {
             if let installedVersion {
@@ -243,7 +243,7 @@ struct SkillMarkdownView: View {
 
     private func refreshOwnedState() async {
         isCheckingCli = true
-        cliStatus = await store.fetchClawdhubStatus()
+        cliStatus = await store.fetchMolthubStatus()
         isCheckingCli = false
         if cliStatus.isInstalled && cliStatus.isLoggedIn {
             isCheckingPublish = true
@@ -257,8 +257,8 @@ struct SkillMarkdownView: View {
 
     private func refreshInstalledState() async {
         isCheckingPublish = true
-        let origin = await store.clawdhubOrigin(for: skill)
-        clawdhubOrigin = origin
+        let origin = await store.molthubOrigin(for: skill)
+        molthubOrigin = origin
         installedVersion = origin?.version
         guard let origin else {
             isCheckingPublish = false
@@ -277,7 +277,7 @@ struct SkillMarkdownView: View {
     private func resetPublishState() {
         isOwned = false
         needsPublish = false
-        clawdhubOrigin = nil
+        molthubOrigin = nil
         installedVersion = nil
         latestVersion = nil
         updateAvailable = false
@@ -293,7 +293,7 @@ struct SkillMarkdownView: View {
     }
 
     private func updateSkill() async {
-        guard let origin = clawdhubOrigin else { return }
+        guard let origin = molthubOrigin else { return }
         isUpdating = true
         do {
             try await store.updateInstalledSkill(
@@ -309,7 +309,7 @@ struct SkillMarkdownView: View {
     }
 
     private func copyLoginCommand() {
-        let command = "bunx clawdhub@latest login"
+        let command = "bunx molthub@latest login"
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
             pasteboard.setString(command, forType: .string)
@@ -320,14 +320,14 @@ struct SkillMarkdownView: View {
         NSWorkspace.shared.open(url)
     }
 
-    private var clawdhubURL: URL? {
-        let slug = isOwned ? skill.name : clawdhubOrigin?.slug
+    private var molthubURL: URL? {
+        let slug = isOwned ? skill.name : molthubOrigin?.slug
         guard let slug else { return nil }
         return URL(string: "https://clawdhub.com/skills/\(slug)")
     }
 
-    private func openClawdhubURL() {
-        guard let url = clawdhubURL else { return }
+    private func openMolthubURL() {
+        guard let url = molthubURL else { return }
         NSWorkspace.shared.open(url)
     }
 

--- a/Sources/CodexSkillManager/Skills/Local/Detail/SkillMarkdownView.swift
+++ b/Sources/CodexSkillManager/Skills/Local/Detail/SkillMarkdownView.swift
@@ -10,7 +10,7 @@ struct SkillMarkdownView: View {
 
     @State private var needsPublish = false
     @State private var isOwned = false
-    @State private var molthubOrigin: SkillFileWorker.MolthubOrigin?
+    @State private var clawhubOrigin: SkillFileWorker.ClawhubOrigin?
     @State private var installedVersion: String?
     @State private var latestVersion: String?
     @State private var updateAvailable = false
@@ -35,7 +35,7 @@ struct SkillMarkdownView: View {
             VStack(alignment: .leading, spacing: 16) {
                 if isOwned {
                     publishSection
-                } else if molthubOrigin != nil {
+                } else if clawhubOrigin != nil {
                     installSection
                 }
                 Markdown(markdown)
@@ -56,14 +56,14 @@ struct SkillMarkdownView: View {
         .navigationTitle(skill.displayName)
         .navigationSubtitle(skill.folderPath)
         .toolbar {
-            if molthubURL != nil {
+            if clawhubURL != nil {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
-                        openMolthubURL()
+                        openClawhubURL()
                     } label: {
                         Image(systemName: "globe")
                     }
-                    .help("Open on Molthub")
+                    .help("Open on Clawhub")
                 }
             }
         }
@@ -104,7 +104,7 @@ struct SkillMarkdownView: View {
 
     private var publishHeader: some View {
         HStack(spacing: 8) {
-            Text("Molthub")
+            Text("Clawhub")
                 .font(.headline)
             Spacer()
             if isCheckingPublish || isCheckingCli {
@@ -117,7 +117,7 @@ struct SkillMarkdownView: View {
     @ViewBuilder
     private var publishContent: some View {
         if isCheckingCli || isCheckingPublish {
-            Text("Checking Molthub status…")
+            Text("Checking Clawhub status…")
                 .foregroundStyle(.secondary)
         } else if !cliStatus.isInstalled {
             publishInstallContent
@@ -130,7 +130,7 @@ struct SkillMarkdownView: View {
 
     private var publishInstallContent: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Install Bun to run the Molthub CLI.")
+            Text("Install Bun to run the Clawhub CLI.")
                 .foregroundStyle(.secondary)
 
             Button("Install Bun") {
@@ -142,7 +142,7 @@ struct SkillMarkdownView: View {
 
     private var publishLoginContent: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Run bunx molthub@latest login in your Terminal, then check again.")
+            Text("Run bunx clawhub@latest login in your Terminal, then check again.")
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 12) {
@@ -173,12 +173,12 @@ struct SkillMarkdownView: View {
                 Text(needsPublish ? "Changes detected. Publish an update." : "No unpublished changes.")
                     .foregroundStyle(.secondary)
             } else {
-                Text("Not yet published on Molthub.")
+                Text("Not yet published on Clawhub.")
                     .foregroundStyle(.secondary)
             }
 
             HStack(spacing: 12) {
-                Button(publishedVersion == nil ? "Publish to Molthub" : "Update on Molthub") {
+                Button(publishedVersion == nil ? "Publish to Clawhub" : "Update on Clawhub") {
                     publishSheetSkill = skill
                 }
                 .buttonStyle(.borderedProminent)
@@ -205,7 +205,7 @@ struct SkillMarkdownView: View {
     @ViewBuilder
     private var installContent: some View {
         if isCheckingPublish {
-            Text("Checking Molthub status…")
+            Text("Checking Clawhub status…")
                 .foregroundStyle(.secondary)
         } else {
             if let installedVersion {
@@ -243,7 +243,7 @@ struct SkillMarkdownView: View {
 
     private func refreshOwnedState() async {
         isCheckingCli = true
-        cliStatus = await store.fetchMolthubStatus()
+        cliStatus = await store.fetchClawhubStatus()
         isCheckingCli = false
         if cliStatus.isInstalled && cliStatus.isLoggedIn {
             isCheckingPublish = true
@@ -257,8 +257,8 @@ struct SkillMarkdownView: View {
 
     private func refreshInstalledState() async {
         isCheckingPublish = true
-        let origin = await store.molthubOrigin(for: skill)
-        molthubOrigin = origin
+        let origin = await store.clawhubOrigin(for: skill)
+        clawhubOrigin = origin
         installedVersion = origin?.version
         guard let origin else {
             isCheckingPublish = false
@@ -277,7 +277,7 @@ struct SkillMarkdownView: View {
     private func resetPublishState() {
         isOwned = false
         needsPublish = false
-        molthubOrigin = nil
+        clawhubOrigin = nil
         installedVersion = nil
         latestVersion = nil
         updateAvailable = false
@@ -293,7 +293,7 @@ struct SkillMarkdownView: View {
     }
 
     private func updateSkill() async {
-        guard let origin = molthubOrigin else { return }
+        guard let origin = clawhubOrigin else { return }
         isUpdating = true
         do {
             try await store.updateInstalledSkill(
@@ -309,7 +309,7 @@ struct SkillMarkdownView: View {
     }
 
     private func copyLoginCommand() {
-        let command = "bunx molthub@latest login"
+        let command = "bunx clawhub@latest login"
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
             pasteboard.setString(command, forType: .string)
@@ -320,14 +320,14 @@ struct SkillMarkdownView: View {
         NSWorkspace.shared.open(url)
     }
 
-    private var molthubURL: URL? {
-        let slug = isOwned ? skill.name : molthubOrigin?.slug
+    private var clawhubURL: URL? {
+        let slug = isOwned ? skill.name : clawhubOrigin?.slug
         guard let slug else { return nil }
-        return URL(string: "https://clawdhub.com/skills/\(slug)")
+        return URL(string: "https://clawhub.ai/skills/\(slug)")
     }
 
-    private func openMolthubURL() {
-        guard let url = molthubURL else { return }
+    private func openClawhubURL() {
+        guard let url = clawhubURL else { return }
         NSWorkspace.shared.open(url)
     }
 

--- a/Sources/CodexSkillManager/Skills/Local/Publish/PublishSkillSheet.swift
+++ b/Sources/CodexSkillManager/Skills/Local/Publish/PublishSkillSheet.swift
@@ -19,7 +19,7 @@ struct PublishSkillSheet: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Publish Skill")
                     .font(.title.bold())
-                Text("Push changes for \(skill.displayName) to Clawdhub.")
+                Text("Push changes for \(skill.displayName) to Molthub.")
                     .foregroundStyle(.secondary)
             }
 

--- a/Sources/CodexSkillManager/Skills/Local/Publish/PublishSkillSheet.swift
+++ b/Sources/CodexSkillManager/Skills/Local/Publish/PublishSkillSheet.swift
@@ -19,7 +19,7 @@ struct PublishSkillSheet: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Publish Skill")
                     .font(.title.bold())
-                Text("Push changes for \(skill.displayName) to Molthub.")
+                Text("Push changes for \(skill.displayName) to Clawhub.")
                     .foregroundStyle(.secondary)
             }
 

--- a/Sources/CodexSkillManager/Skills/Local/SkillStore.swift
+++ b/Sources/CodexSkillManager/Skills/Local/SkillStore.swift
@@ -49,7 +49,7 @@ import Observation
 
     private let fileWorker = SkillFileWorker()
     private let importWorker = SkillImportWorker()
-    private let cliWorker = ClawdhubCLIWorker()
+    private let cliWorker = MolthubCLIWorker()
     private let customPathStore: CustomPathStore
 
     init(customPathStore: CustomPathStore = CustomPathStore()) {
@@ -225,8 +225,8 @@ import Observation
         return !FileManager.default.fileExists(atPath: originURL.path)
     }
 
-    func clawdhubOrigin(for skill: Skill) async -> SkillFileWorker.ClawdhubOrigin? {
-        await fileWorker.readClawdhubOrigin(from: skill.folderURL)
+    func molthubOrigin(for skill: Skill) async -> SkillFileWorker.MolthubOrigin? {
+        await fileWorker.readMolthubOrigin(from: skill.folderURL)
     }
 
     func isInstalled(slug: String) -> Bool {
@@ -312,7 +312,7 @@ import Observation
         savePublishState(for: skill.name, hash: hash)
     }
 
-    func fetchClawdhubStatus() async -> CliStatus {
+    func fetchMolthubStatus() async -> CliStatus {
         let status = await cliWorker.fetchStatus()
         return CliStatus(
             isInstalled: status.isInstalled,
@@ -394,7 +394,7 @@ import Observation
     }
 
     func nextVersion(from current: String, bump: PublishBump) -> String? {
-        ClawdhubCLIWorker.bumpVersion(current, bump: bump)
+        MolthubCLIWorker.bumpVersion(current, bump: bump)
     }
 
     func isNewerVersion(_ latest: String, than installed: String) -> Bool {

--- a/Sources/CodexSkillManager/Skills/Local/SkillStore.swift
+++ b/Sources/CodexSkillManager/Skills/Local/SkillStore.swift
@@ -219,10 +219,13 @@ import Observation
         if skill.customPath != nil {
             return true
         }
-        let originURL = skill.folderURL
+        let calwdhubOriginURL = skill.folderURL
             .appendingPathComponent(".clawdhub")
             .appendingPathComponent("origin.json")
-        return !FileManager.default.fileExists(atPath: originURL.path)
+        let originURL = skill.folderURL
+            .appendingPathComponent(".molthub")
+            .appendingPathComponent("origin.json")
+        return !FileManager.default.fileExists(atPath: calwdhubOriginURL.path()) && !FileManager.default.fileExists(atPath: originURL.path)
     }
 
     func molthubOrigin(for skill: Skill) async -> SkillFileWorker.MolthubOrigin? {

--- a/Sources/CodexSkillManager/Skills/Local/SkillStore.swift
+++ b/Sources/CodexSkillManager/Skills/Local/SkillStore.swift
@@ -49,7 +49,7 @@ import Observation
 
     private let fileWorker = SkillFileWorker()
     private let importWorker = SkillImportWorker()
-    private let cliWorker = MolthubCLIWorker()
+    private let cliWorker = ClawhubCLIWorker()
     private let customPathStore: CustomPathStore
 
     init(customPathStore: CustomPathStore = CustomPathStore()) {
@@ -219,17 +219,17 @@ import Observation
         if skill.customPath != nil {
             return true
         }
-        let calwdhubOriginURL = skill.folderURL
+        let clawhubOriginURL = skill.folderURL
             .appendingPathComponent(".clawdhub")
             .appendingPathComponent("origin.json")
         let originURL = skill.folderURL
-            .appendingPathComponent(".molthub")
+            .appendingPathComponent(".clawhub")
             .appendingPathComponent("origin.json")
-        return !FileManager.default.fileExists(atPath: calwdhubOriginURL.path()) && !FileManager.default.fileExists(atPath: originURL.path)
+        return !FileManager.default.fileExists(atPath: clawhubOriginURL.path()) && !FileManager.default.fileExists(atPath: originURL.path)
     }
 
-    func molthubOrigin(for skill: Skill) async -> SkillFileWorker.MolthubOrigin? {
-        await fileWorker.readMolthubOrigin(from: skill.folderURL)
+    func clawhubOrigin(for skill: Skill) async -> SkillFileWorker.ClawhubOrigin? {
+        await fileWorker.readClawhubOrigin(from: skill.folderURL)
     }
 
     func isInstalled(slug: String) -> Bool {
@@ -315,7 +315,7 @@ import Observation
         savePublishState(for: skill.name, hash: hash)
     }
 
-    func fetchMolthubStatus() async -> CliStatus {
+    func fetchClawhubStatus() async -> CliStatus {
         let status = await cliWorker.fetchStatus()
         return CliStatus(
             isInstalled: status.isInstalled,
@@ -397,7 +397,7 @@ import Observation
     }
 
     func nextVersion(from current: String, bump: PublishBump) -> String? {
-        MolthubCLIWorker.bumpVersion(current, bump: bump)
+        ClawhubCLIWorker.bumpVersion(current, bump: bump)
     }
 
     func isNewerVersion(_ latest: String, than installed: String) -> Bool {

--- a/Sources/CodexSkillManager/Skills/Remote/RemoteSkillClient.swift
+++ b/Sources/CodexSkillManager/Skills/Remote/RemoteSkillClient.swift
@@ -21,7 +21,7 @@ extension RemoteSkillClient {
         return URLSession(configuration: config)
     }()
 
-    static func live(baseURL: URL = URL(string: "https://clawdhub.com")!) -> RemoteSkillClient {
+    static func live(baseURL: URL = URL(string: "https://clawhub.ai")!) -> RemoteSkillClient {
         let session = Self.session
 
         return RemoteSkillClient(

--- a/Sources/CodexSkillManager/Skills/Remote/RemoteSkillDetailView.swift
+++ b/Sources/CodexSkillManager/Skills/Remote/RemoteSkillDetailView.swift
@@ -17,22 +17,22 @@ struct RemoteSkillDetailView: View {
                 }
             }
             .navigationTitle(skill.displayName)
-            .navigationSubtitle("Clawdhub")
+            .navigationSubtitle("Molthub")
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
-                        openClawdhubURL(for: skill)
+                        openMolthubURL(for: skill)
                     } label: {
                         Image(systemName: "globe")
                     }
-                    .help("Open on Clawdhub")
+                    .help("Open on Molthub")
                 }
             }
         } else {
             ContentUnavailableView(
                 "Select a skill",
                 systemImage: "sparkles",
-                description: Text("Pick a skill from Clawdhub.")
+                description: Text("Pick a skill from Molthub.")
             )
         }
     }
@@ -96,7 +96,7 @@ struct RemoteSkillDetailView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func openClawdhubURL(for skill: RemoteSkill) {
+    private func openMolthubURL(for skill: RemoteSkill) {
         guard let url = URL(string: "https://clawdhub.com/skills/\(skill.slug)") else { return }
         NSWorkspace.shared.open(url)
     }

--- a/Sources/CodexSkillManager/Skills/Remote/RemoteSkillDetailView.swift
+++ b/Sources/CodexSkillManager/Skills/Remote/RemoteSkillDetailView.swift
@@ -17,22 +17,22 @@ struct RemoteSkillDetailView: View {
                 }
             }
             .navigationTitle(skill.displayName)
-            .navigationSubtitle("Molthub")
+            .navigationSubtitle("Clawhub")
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
-                        openMolthubURL(for: skill)
+                        openClawhubURL(for: skill)
                     } label: {
                         Image(systemName: "globe")
                     }
-                    .help("Open on Molthub")
+                    .help("Open on Clawhub")
                 }
             }
         } else {
             ContentUnavailableView(
                 "Select a skill",
                 systemImage: "sparkles",
-                description: Text("Pick a skill from Molthub.")
+                description: Text("Pick a skill from Clawhub.")
             )
         }
     }
@@ -96,8 +96,8 @@ struct RemoteSkillDetailView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func openMolthubURL(for skill: RemoteSkill) {
-        guard let url = URL(string: "https://clawdhub.com/skills/\(skill.slug)") else { return }
+    private func openClawhubURL(for skill: RemoteSkill) {
+        guard let url = URL(string: "https://clawhub.ai/skills/\(skill.slug)") else { return }
         NSWorkspace.shared.open(url)
     }
 

--- a/Sources/CodexSkillManager/Skills/Shared/SkillSource.swift
+++ b/Sources/CodexSkillManager/Skills/Shared/SkillSource.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum SkillSource: String, CaseIterable, Identifiable {
     case local = "Local"
-    case molthub = "Molthub"
+    case clawhub = "Clawhub"
 
     var id: String { rawValue }
 }

--- a/Sources/CodexSkillManager/Skills/Shared/SkillSource.swift
+++ b/Sources/CodexSkillManager/Skills/Shared/SkillSource.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum SkillSource: String, CaseIterable, Identifiable {
     case local = "Local"
-    case clawdhub = "Clawdhub"
+    case molthub = "Molthub"
 
     var id: String { rawValue }
 }

--- a/Sources/CodexSkillManager/Skills/Sidebar/SidebarHeaderView.swift
+++ b/Sources/CodexSkillManager/Skills/Sidebar/SidebarHeaderView.swift
@@ -17,7 +17,7 @@ struct SidebarHeaderView: View {
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(source == .local ? "Installed Skills" : "Clawdhub")
+                Text(source == .local ? "Installed Skills" : "Molthub")
                     .font(.title2.bold())
                     .foregroundStyle(.primary)
                 Text("\(skillCount) skills")

--- a/Sources/CodexSkillManager/Skills/Sidebar/SidebarHeaderView.swift
+++ b/Sources/CodexSkillManager/Skills/Sidebar/SidebarHeaderView.swift
@@ -17,7 +17,7 @@ struct SidebarHeaderView: View {
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(source == .local ? "Installed Skills" : "Molthub")
+                Text(source == .local ? "Installed Skills" : "Clawhub")
                     .font(.title2.bold())
                     .foregroundStyle(.primary)
                 Text("\(skillCount) skills")

--- a/Sources/CodexSkillManager/Skills/Sidebar/SkillListView.swift
+++ b/Sources/CodexSkillManager/Skills/Sidebar/SkillListView.swift
@@ -61,7 +61,7 @@ struct SkillListView: View {
                         switch source {
                         case .local:
                             await store.loadSkills()
-                        case .clawdhub:
+                        case .molthub:
                             await remoteStore.loadLatest()
                         }
                     }
@@ -138,9 +138,9 @@ struct SkillListView: View {
         // Group user directory skills separately to avoid custom-path slugs hiding them.
         let platformSkills = store.groupedPlatformSkills(from: localSkills)
         let mine = platformSkills.filter { store.isOwnedSkill($0.skill) }
-        let clawdhub = platformSkills.filter { !store.isOwnedSkill($0.skill) }
+        let molthub = platformSkills.filter { !store.isOwnedSkill($0.skill) }
 
-        let hasAnySkills = !mine.isEmpty || !clawdhub.isEmpty || !store.customPaths.isEmpty
+        let hasAnySkills = !mine.isEmpty || !molthub.isEmpty || !store.customPaths.isEmpty
 
         if !hasAnySkills {
             Text("No skills yet.")
@@ -151,8 +151,8 @@ struct SkillListView: View {
             Section("Mine") {
                 localRows(for: mine)
             }
-            Section("Clawdhub") {
-                localRows(for: clawdhub)
+            Section("Molthub") {
+                localRows(for: molthub)
             }
 
             // Custom path sections

--- a/Sources/CodexSkillManager/Skills/Sidebar/SkillListView.swift
+++ b/Sources/CodexSkillManager/Skills/Sidebar/SkillListView.swift
@@ -61,7 +61,7 @@ struct SkillListView: View {
                         switch source {
                         case .local:
                             await store.loadSkills()
-                        case .molthub:
+                        case .clawhub:
                             await remoteStore.loadLatest()
                         }
                     }
@@ -138,9 +138,9 @@ struct SkillListView: View {
         // Group user directory skills separately to avoid custom-path slugs hiding them.
         let platformSkills = store.groupedPlatformSkills(from: localSkills)
         let mine = platformSkills.filter { store.isOwnedSkill($0.skill) }
-        let molthub = platformSkills.filter { !store.isOwnedSkill($0.skill) }
+        let clawhub = platformSkills.filter { !store.isOwnedSkill($0.skill) }
 
-        let hasAnySkills = !mine.isEmpty || !molthub.isEmpty || !store.customPaths.isEmpty
+        let hasAnySkills = !mine.isEmpty || !clawhub.isEmpty || !store.customPaths.isEmpty
 
         if !hasAnySkills {
             Text("No skills yet.")
@@ -151,8 +151,8 @@ struct SkillListView: View {
             Section("Mine") {
                 localRows(for: mine)
             }
-            Section("Molthub") {
-                localRows(for: molthub)
+            Section("Clawhub") {
+                localRows(for: clawhub)
             }
 
             // Custom path sections

--- a/Sources/CodexSkillManager/Skills/SkillSplitView.swift
+++ b/Sources/CodexSkillManager/Skills/SkillSplitView.swift
@@ -64,7 +64,7 @@ struct SkillSplitView: View {
             .searchable(
                 text: $searchText,
                 placement: .sidebar,
-                prompt: source == .local ? "Filter skills" : "Search Molthub"
+                prompt: source == .local ? "Filter skills" : "Search Clawhub"
             )
     }
 
@@ -99,14 +99,14 @@ struct SkillSplitView: View {
         switch source {
         case .local:
             SkillDetailView()
-        case .molthub:
+        case .clawhub:
             RemoteSkillDetailView()
         }
     }
 
     @ToolbarContentBuilder
     private func toolbarContent() -> some CustomizableToolbarContent {
-        if source == .molthub {
+        if source == .clawhub {
             ToolbarItem(id: "download") {
                 Button {
                     presentRemoteInstallSheet()
@@ -373,7 +373,7 @@ private struct SkillSplitLifecycleModifier: ViewModifier {
                 }
             }
             .onChange(of: searchText) { _, newValue in
-                guard source == .molthub else { return }
+                guard source == .clawhub else { return }
                 searchTask?.cancel()
                 searchTask = Task {
                     try? await Task.sleep(for: .milliseconds(300))

--- a/Sources/CodexSkillManager/Skills/SkillSplitView.swift
+++ b/Sources/CodexSkillManager/Skills/SkillSplitView.swift
@@ -64,7 +64,7 @@ struct SkillSplitView: View {
             .searchable(
                 text: $searchText,
                 placement: .sidebar,
-                prompt: source == .local ? "Filter skills" : "Search Clawdhub"
+                prompt: source == .local ? "Filter skills" : "Search Molthub"
             )
     }
 
@@ -99,14 +99,14 @@ struct SkillSplitView: View {
         switch source {
         case .local:
             SkillDetailView()
-        case .clawdhub:
+        case .molthub:
             RemoteSkillDetailView()
         }
     }
 
     @ToolbarContentBuilder
     private func toolbarContent() -> some CustomizableToolbarContent {
-        if source == .clawdhub {
+        if source == .molthub {
             ToolbarItem(id: "download") {
                 Button {
                     presentRemoteInstallSheet()
@@ -373,7 +373,7 @@ private struct SkillSplitLifecycleModifier: ViewModifier {
                 }
             }
             .onChange(of: searchText) { _, newValue in
-                guard source == .clawdhub else { return }
+                guard source == .molthub else { return }
                 searchTask?.cancel()
                 searchTask = Task {
                     try? await Task.sleep(for: .milliseconds(300))

--- a/Sources/CodexSkillManager/Workers/MolthubCLIWorker.swift
+++ b/Sources/CodexSkillManager/Workers/MolthubCLIWorker.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-actor ClawdhubCLIWorker {
+actor MolthubCLIWorker {
     struct CliStatus: Sendable {
         let isInstalled: Bool
         let isLoggedIn: Bool
@@ -21,7 +21,7 @@ actor ClawdhubCLIWorker {
         do {
             let whoami = try runProcess(
                 executable: bunx,
-                arguments: ["clawdhub@latest", "whoami"]
+                arguments: ["molthub@latest", "whoami"]
             )
             let username = lastNonEmptyLine(from: whoami)
             return CliStatus(
@@ -48,7 +48,7 @@ actor ClawdhubCLIWorker {
         tags: [String]
     ) throws {
         guard let bunx = resolveBunxPath() else {
-            throw NSError(domain: "ClawdhubPublish", code: 1, userInfo: [
+            throw NSError(domain: "MolthubPublish", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "Bun is not installed."
             ])
         }
@@ -95,7 +95,7 @@ actor ClawdhubCLIWorker {
         tags: [String]
     ) -> [String] {
         var args = [
-            "clawdhub@latest",
+            "molthub@latest",
             "publish",
             skillURL.path,
             "--version",
@@ -185,7 +185,7 @@ actor ClawdhubCLIWorker {
             .joined(separator: output.isEmpty || errorOutput.isEmpty ? "" : "\n")
 
         if process.terminationStatus != 0 {
-            throw NSError(domain: "ClawdhubPublish", code: Int(process.terminationStatus), userInfo: [
+            throw NSError(domain: "MolthubPublish", code: Int(process.terminationStatus), userInfo: [
                 NSLocalizedDescriptionKey: errorOutput.isEmpty ? output : errorOutput
             ])
         }

--- a/Sources/CodexSkillManager/Workers/MolthubCLIWorker.swift
+++ b/Sources/CodexSkillManager/Workers/MolthubCLIWorker.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-actor MolthubCLIWorker {
+actor ClawhubCLIWorker {
     struct CliStatus: Sendable {
         let isInstalled: Bool
         let isLoggedIn: Bool
@@ -21,7 +21,7 @@ actor MolthubCLIWorker {
         do {
             let whoami = try runProcess(
                 executable: bunx,
-                arguments: ["molthub@latest", "whoami"]
+                arguments: ["clawhub@latest", "whoami"]
             )
             let username = lastNonEmptyLine(from: whoami)
             return CliStatus(
@@ -48,7 +48,7 @@ actor MolthubCLIWorker {
         tags: [String]
     ) throws {
         guard let bunx = resolveBunxPath() else {
-            throw NSError(domain: "MolthubPublish", code: 1, userInfo: [
+            throw NSError(domain: "ClawhubPublish", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "Bun is not installed."
             ])
         }
@@ -95,7 +95,7 @@ actor MolthubCLIWorker {
         tags: [String]
     ) -> [String] {
         var args = [
-            "molthub@latest",
+            "clawhub@latest",
             "publish",
             skillURL.path,
             "--version",
@@ -185,7 +185,7 @@ actor MolthubCLIWorker {
             .joined(separator: output.isEmpty || errorOutput.isEmpty ? "" : "\n")
 
         if process.terminationStatus != 0 {
-            throw NSError(domain: "MolthubPublish", code: Int(process.terminationStatus), userInfo: [
+            throw NSError(domain: "ClawhubPublish", code: Int(process.terminationStatus), userInfo: [
                 NSLocalizedDescriptionKey: errorOutput.isEmpty ? output : errorOutput
             ])
         }

--- a/Sources/CodexSkillManager/Workers/SkillFileWorker.swift
+++ b/Sources/CodexSkillManager/Workers/SkillFileWorker.swift
@@ -18,7 +18,7 @@ actor SkillFileWorker {
         let stats: SkillStats
     }
 
-    struct ClawdhubOrigin: Sendable {
+    struct MolthubOrigin: Sendable {
         let slug: String
         let version: String?
     }
@@ -77,7 +77,7 @@ actor SkillFileWorker {
                 try fileManager.removeItem(at: finalURL)
             }
             try fileManager.copyItem(at: skillRoot, to: finalURL)
-            try writeClawdhubOrigin(at: finalURL, slug: slug, version: version)
+            try writeMolthubOrigin(at: finalURL, slug: slug, version: version)
         }
 
         guard let preferred = destinations.first else { return nil }
@@ -176,7 +176,7 @@ actor SkillFileWorker {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
-    func readClawdhubOrigin(from skillRoot: URL) -> ClawdhubOrigin? {
+    func readMolthubOrigin(from skillRoot: URL) -> MolthubOrigin? {
         let originURL = skillRoot
             .appendingPathComponent(".clawdhub", isDirectory: true)
             .appendingPathComponent("origin.json")
@@ -187,7 +187,7 @@ actor SkillFileWorker {
         }
 
         let version = json["version"] as? String
-        return ClawdhubOrigin(slug: slug, version: version)
+        return MolthubOrigin(slug: slug, version: version)
     }
 
     private func unzip(_ url: URL, to destination: URL) throws {
@@ -230,7 +230,7 @@ actor SkillFileWorker {
         return nil
     }
 
-    private func writeClawdhubOrigin(at skillRoot: URL, slug: String, version: String?) throws {
+    private func writeMolthubOrigin(at skillRoot: URL, slug: String, version: String?) throws {
         let originDir = skillRoot
             .appendingPathComponent(".clawdhub", isDirectory: true)
         try FileManager.default.createDirectory(at: originDir, withIntermediateDirectories: true)
@@ -239,7 +239,7 @@ actor SkillFileWorker {
         let payload: [String: Any] = [
             "slug": slug,
             "version": version ?? "latest",
-            "source": "clawdhub",
+            "source": "molthub",
             "installedAt": Int(Date().timeIntervalSince1970)
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted])

--- a/Sources/CodexSkillManager/Workers/SkillFileWorker.swift
+++ b/Sources/CodexSkillManager/Workers/SkillFileWorker.swift
@@ -18,7 +18,7 @@ actor SkillFileWorker {
         let stats: SkillStats
     }
 
-    struct MolthubOrigin: Sendable {
+    struct ClawhubOrigin: Sendable {
         let slug: String
         let version: String?
     }
@@ -77,7 +77,7 @@ actor SkillFileWorker {
                 try fileManager.removeItem(at: finalURL)
             }
             try fileManager.copyItem(at: skillRoot, to: finalURL)
-            try writeMolthubOrigin(at: finalURL, slug: slug, version: version)
+            try writeClawhubOrigin(at: finalURL, slug: slug, version: version)
         }
 
         guard let preferred = destinations.first else { return nil }
@@ -146,7 +146,7 @@ actor SkillFileWorker {
         var files: [URL] = []
         for case let fileURL as URL in enumerator {
             let path = fileURL.path
-            if path.contains("/.git/") || path.contains("/.clawdhub/") || path.contains("/.molthub/") {
+            if path.contains("/.git/") || path.contains("/.clawdhub/") || path.contains("/.clawhub/") {
                 continue
             }
             if fileURL.lastPathComponent == ".DS_Store" {
@@ -176,10 +176,10 @@ actor SkillFileWorker {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
-    func readMolthubOrigin(from skillRoot: URL) -> MolthubOrigin? {
+    func readClawhubOrigin(from skillRoot: URL) -> ClawhubOrigin? {
         let originURLs = [
             skillRoot
-                .appendingPathComponent(".molthub", isDirectory: true)
+                .appendingPathComponent(".clawhub", isDirectory: true)
                 .appendingPathComponent("origin.json"),
             skillRoot
                 .appendingPathComponent(".clawdhub", isDirectory: true)
@@ -194,7 +194,7 @@ actor SkillFileWorker {
             }
 
             let version = json["version"] as? String
-            return MolthubOrigin(slug: slug, version: version)
+            return ClawhubOrigin(slug: slug, version: version)
         }
 
         return nil
@@ -240,16 +240,16 @@ actor SkillFileWorker {
         return nil
     }
 
-    private func writeMolthubOrigin(at skillRoot: URL, slug: String, version: String?) throws {
+    private func writeClawhubOrigin(at skillRoot: URL, slug: String, version: String?) throws {
         let originDir = skillRoot
-            .appendingPathComponent(".molthub", isDirectory: true)
+            .appendingPathComponent(".clawhub", isDirectory: true)
         try FileManager.default.createDirectory(at: originDir, withIntermediateDirectories: true)
 
         let originURL = originDir.appendingPathComponent("origin.json")
         let payload: [String: Any] = [
             "slug": slug,
             "version": version ?? "latest",
-            "source": "molthub",
+            "source": "clawhub",
             "installedAt": Int(Date().timeIntervalSince1970)
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted])

--- a/Tests/CodexSkillManagerTests/SkillPathPatternTests.swift
+++ b/Tests/CodexSkillManagerTests/SkillPathPatternTests.swift
@@ -282,13 +282,13 @@ struct PlatformDiscoveryTests {
 struct SkillGroupingTests {
 
     /// Simulates isOwnedSkill logic from SkillStore
-    func isOwnedSkill(_ skill: TestSkill, hasMolthubOrigin: Bool) -> Bool {
+    func isOwnedSkill(_ skill: TestSkill, hasClawhubOrigin: Bool) -> Bool {
         // Skills from custom paths are always considered "owned"
         if skill.customPath != nil {
             return true
         }
-        // For user directory skills, check for molthub origin
-        return !hasMolthubOrigin
+        // For user directory skills, check for clawhub origin
+        return !hasClawhubOrigin
     }
 
     @Test("Custom path skills are always owned")
@@ -304,12 +304,12 @@ struct SkillGroupingTests {
             folderURL: URL(fileURLWithPath: "/Users/test/projects/my-project/.claude/skills/my-skill")
         )
 
-        // Even if it had a molthub origin, custom path skills should be owned
-        #expect(isOwnedSkill(skill, hasMolthubOrigin: false) == true)
-        #expect(isOwnedSkill(skill, hasMolthubOrigin: true) == true)
+        // Even if it had a clawhub origin, custom path skills should be owned
+        #expect(isOwnedSkill(skill, hasClawhubOrigin: false) == true)
+        #expect(isOwnedSkill(skill, hasClawhubOrigin: true) == true)
     }
 
-    @Test("User directory skills ownership depends on molthub origin")
+    @Test("User directory skills ownership depends on clawhub origin")
     func userDirectorySkillsOwnershipDependsOnOrigin() {
         let home = FileManager.default.homeDirectoryForCurrentUser
         let skill = TestSkill(
@@ -320,8 +320,8 @@ struct SkillGroupingTests {
             folderURL: home.appendingPathComponent(".claude/skills/my-skill")
         )
 
-        #expect(isOwnedSkill(skill, hasMolthubOrigin: false) == true)  // Mine
-        #expect(isOwnedSkill(skill, hasMolthubOrigin: true) == false)  // Molthub
+        #expect(isOwnedSkill(skill, hasClawhubOrigin: false) == true)  // Mine
+        #expect(isOwnedSkill(skill, hasClawhubOrigin: true) == false)  // Clawhub
     }
 
     @Test("Skills group correctly by source type")

--- a/Tests/CodexSkillManagerTests/SkillPathPatternTests.swift
+++ b/Tests/CodexSkillManagerTests/SkillPathPatternTests.swift
@@ -282,13 +282,13 @@ struct PlatformDiscoveryTests {
 struct SkillGroupingTests {
 
     /// Simulates isOwnedSkill logic from SkillStore
-    func isOwnedSkill(_ skill: TestSkill, hasClawdhubOrigin: Bool) -> Bool {
+    func isOwnedSkill(_ skill: TestSkill, hasMolthubOrigin: Bool) -> Bool {
         // Skills from custom paths are always considered "owned"
         if skill.customPath != nil {
             return true
         }
-        // For user directory skills, check for clawdhub origin
-        return !hasClawdhubOrigin
+        // For user directory skills, check for molthub origin
+        return !hasMolthubOrigin
     }
 
     @Test("Custom path skills are always owned")
@@ -304,12 +304,12 @@ struct SkillGroupingTests {
             folderURL: URL(fileURLWithPath: "/Users/test/projects/my-project/.claude/skills/my-skill")
         )
 
-        // Even if it had a clawdhub origin, custom path skills should be owned
-        #expect(isOwnedSkill(skill, hasClawdhubOrigin: false) == true)
-        #expect(isOwnedSkill(skill, hasClawdhubOrigin: true) == true)
+        // Even if it had a molthub origin, custom path skills should be owned
+        #expect(isOwnedSkill(skill, hasMolthubOrigin: false) == true)
+        #expect(isOwnedSkill(skill, hasMolthubOrigin: true) == true)
     }
 
-    @Test("User directory skills ownership depends on clawdhub origin")
+    @Test("User directory skills ownership depends on molthub origin")
     func userDirectorySkillsOwnershipDependsOnOrigin() {
         let home = FileManager.default.homeDirectoryForCurrentUser
         let skill = TestSkill(
@@ -320,8 +320,8 @@ struct SkillGroupingTests {
             folderURL: home.appendingPathComponent(".claude/skills/my-skill")
         )
 
-        #expect(isOwnedSkill(skill, hasClawdhubOrigin: false) == true)  // Mine
-        #expect(isOwnedSkill(skill, hasClawdhubOrigin: true) == false)  // Clawdhub
+        #expect(isOwnedSkill(skill, hasMolthubOrigin: false) == true)  // Mine
+        #expect(isOwnedSkill(skill, hasMolthubOrigin: true) == false)  // Molthub
     }
 
     @Test("Skills group correctly by source type")

--- a/appcast.xml
+++ b/appcast.xml
@@ -90,7 +90,7 @@
 <h2>CodexSkillManager-1.2.3</h2>
 <ul>
 <li>Add OpenCode as a supported local skill platform.</li>
-<li>Improve Clawdhub browsing with cached detail loading.</li>
+<li>Improve Molthub browsing with cached detail loading.</li>
 <li>Show skill stats consistently in the sidebar and detail view.</li>
 <li>Fix reload behavior and search typing responsiveness.</li>
 </ul>

--- a/appcast.xml
+++ b/appcast.xml
@@ -90,7 +90,7 @@
 <h2>CodexSkillManager-1.2.3</h2>
 <ul>
 <li>Add OpenCode as a supported local skill platform.</li>
-<li>Improve Molthub browsing with cached detail loading.</li>
+<li>Improve Clawhub browsing with cached detail loading.</li>
 <li>Show skill stats consistently in the sidebar and detail view.</li>
 <li>Fix reload behavior and search typing responsiveness.</li>
 </ul>


### PR DESCRIPTION
Renamed all mentions of Clawdhub to Clawhub (without **D**)

Also renamed the `.clawdhub` path for storing the `origin.json` file, but handling both old and new paths. 
Maybe that we could just leave as it was to keep it simple.